### PR TITLE
Fix Types filter in List-Zones and Get-ZoneRecordSets

### DIFF
--- a/fastdns/Get-ZoneRecordSets.ps1
+++ b/fastdns/Get-ZoneRecordSets.ps1
@@ -13,7 +13,7 @@ function Get-ZoneRecordSets
         [Parameter(Mandatory=$false)] [string] $AccountSwitchKey
     )
 
-    $Path = "/config-dns/v2/zones/$Zone/recordsets?page=$Page&pageSize=$PageSize&search=$Search&showAll=$ShowAllString&sortBy=$SortBy&type=$TypesaccountSwitchKey=$AccountSwitchKey"
+    $Path = "/config-dns/v2/zones/$Zone/recordsets?page=$Page&pageSize=$PageSize&search=$Search&showAll=$ShowAllString&sortBy=$SortBy&types=$Types&accountSwitchKey=$AccountSwitchKey"
 
     try {
         $Result = Invoke-AkamaiRestMethod -Method GET -Path $Path -EdgeRCFile $EdgeRCFile -Section $Section

--- a/fastdns/List-Zones.ps1
+++ b/fastdns/List-Zones.ps1
@@ -17,7 +17,7 @@ function List-Zones
     $ShowAllString = $ShowAll.IsPresent.ToString().ToLower()
     if(!$ShowAll){ $ShowAllString = '' }
 
-    $Path = "/config-dns/v2/zones?contractIds=$ContractIDs&page=$Page&pageSize=$PageSize&search=$Search&showAll=$ShowAllString&sortBy=$SortBy&type=$Types&accountSwitchKey=$AccountSwitchKey"
+    $Path = "/config-dns/v2/zones?contractIds=$ContractIDs&page=$Page&pageSize=$PageSize&search=$Search&showAll=$ShowAllString&sortBy=$SortBy&types=$Types&accountSwitchKey=$AccountSwitchKey"
 
     try {
         $Result = Invoke-AkamaiRestMethod -Method GET -Path $Path -EdgeRCFile $EdgeRCFile -Section $Section


### PR DESCRIPTION
This change fixes the `-Types` filter in the `List-Zones` and `Get-ZoneRecordSets` functions. The query string was using `type=` instead of `types=`.
https://developer.akamai.com/api/cloud_security/edge_dns_zone_management/v2.html#getzones
https://developer.akamai.com/api/cloud_security/edge_dns_zone_management/v2.html#getzonerecordsets

It also fixes `-AccountSwitchKey` in `Get-ZoneRecordsets` which was missing an `&` in the query string.