### PR TITLE
Fix for Get-MasterZoneFile HTTP 406 error

### DIFF
--- a/fastdns/Get-MasterZoneFile.ps1
+++ b/fastdns/Get-MasterZoneFile.ps1
@@ -10,7 +10,7 @@ function Get-MasterZoneFile
     $Path = "/config-dns/v2/zones/$Zone/zone-file`?accountSwitchKey=$AccountSwitchKey"
 
     try {
-        $Result = Invoke-AkamaiRestMethod -Method GET -Path $Path -EdgeRCFile $EdgeRCFile -Section $Section
+        $Result = Invoke-AkamaiRestMethod -Method GET -Path $Path -AcceptHeader 'text/dns' -EdgeRCFile $EdgeRCFile -Section $Section
         return $Result
     }
     catch {

--- a/fastdns/Get-MasterZoneFile.ps1
+++ b/fastdns/Get-MasterZoneFile.ps1
@@ -8,9 +8,12 @@ function Get-MasterZoneFile
     )
 
     $Path = "/config-dns/v2/zones/$Zone/zone-file`?accountSwitchKey=$AccountSwitchKey"
+    $AdditionalHeaders = @{
+        Accept = 'text/dns'
+    }
 
     try {
-        $Result = Invoke-AkamaiRestMethod -Method GET -Path $Path -AcceptHeader 'text/dns' -EdgeRCFile $EdgeRCFile -Section $Section
+        $Result = Invoke-AkamaiRestMethod -Method GET -Path $Path -AdditionalHeaders $AdditionalHeaders -EdgeRCFile $EdgeRCFile -Section $Section
         return $Result
     }
     catch {

--- a/shared/Invoke-AkamaiRestMethod.ps1
+++ b/shared/Invoke-AkamaiRestMethod.ps1
@@ -45,8 +45,6 @@ Should contain the POST/PUT Body. The body should be structured like a JSON obje
 Hashtable of additional request headers to add
 .PARAMETER Staging
 Image Manager requests only. Changes IM host from production to staging. For non-IM requests does nothing.
-.PARAMETER AcceptHeader
-The 'Accept' HTTP header that should be sent with this request. Defaults to 'application/json'.
 .EXAMPLE
 Invoke-AkamaiRestMethod -Method GET -Path '/path/to/api?withParams=true' -EdgeRCFile ~/my.edgerc -Section 'papi'
 .LINK
@@ -62,8 +60,7 @@ function Invoke-AkamaiRestMethod
         [Parameter(Mandatory=$false)] [string] $Section = 'default',
         [Parameter(Mandatory=$false)] [hashtable] $AdditionalHeaders,
         [Parameter(Mandatory=$false)] [boolean] $Staging,
-        [Parameter(Mandatory=$false)] [string] $MaxBody = 131072,
-        [Parameter(Mandatory=$false)] [string] $AcceptHeader = 'application/json'
+        [Parameter(Mandatory=$false)] [string] $MaxBody = 131072
         )
 
     # Get credentials from EdgeRC
@@ -166,7 +163,7 @@ function Invoke-AkamaiRestMethod
 
     #Add Auth & Accept headers
     $Headers.Add('Authorization',$AuthorizationHeader)
-    $Headers.Add('Accept',$AcceptHeader)
+    $Headers.Add('Accept','application/json')
     $Headers.Add('Content-Type', 'application/json')
 
     #Add additional headers
@@ -204,7 +201,7 @@ function Invoke-AkamaiRestMethod
                 else {
                     $Response = Invoke-RestMethod -Method $Method -Uri $ReqURL -Headers $Headers -Body $Body
                 }
-                
+
             }
             else {
                 if($UseProxy) {
@@ -229,7 +226,7 @@ function Invoke-AkamaiRestMethod
                 else {
                     $Response = Invoke-RestMethod -Method $Method -Uri $ReqURL -Headers $Headers -MaximumRedirection 0 -ErrorAction SilentlyContinue
                 }
-    
+
                 #Redirects aren't well handled due to signatures needing regenerated
                 if($Response.redirectLink){
                     $Response = Invoke-AkamaiRestMethod -Method $Method -Path $Response.redirectLink  -AdditionalHeaders $AdditionalHeaders -EdgeRCFile $EdgeRCFile -Section $Section

--- a/shared/Invoke-AkamaiRestMethod.ps1
+++ b/shared/Invoke-AkamaiRestMethod.ps1
@@ -45,6 +45,8 @@ Should contain the POST/PUT Body. The body should be structured like a JSON obje
 Hashtable of additional request headers to add
 .PARAMETER Staging
 Image Manager requests only. Changes IM host from production to staging. For non-IM requests does nothing.
+.PARAMETER AcceptHeader
+The 'Accept' HTTP header that should be sent with this request. Defaults to 'application/json'.
 .EXAMPLE
 Invoke-AkamaiRestMethod -Method GET -Path '/path/to/api?withParams=true' -EdgeRCFile ~/my.edgerc -Section 'papi'
 .LINK
@@ -60,7 +62,8 @@ function Invoke-AkamaiRestMethod
         [Parameter(Mandatory=$false)] [string] $Section = 'default',
         [Parameter(Mandatory=$false)] [hashtable] $AdditionalHeaders,
         [Parameter(Mandatory=$false)] [boolean] $Staging,
-        [Parameter(Mandatory=$false)] [string] $MaxBody = 131072
+        [Parameter(Mandatory=$false)] [string] $MaxBody = 131072,
+        [Parameter(Mandatory=$false)] [string] $AcceptHeader = 'application/json'
         )
 
     # Get credentials from EdgeRC
@@ -163,7 +166,7 @@ function Invoke-AkamaiRestMethod
 
     #Add Auth & Accept headers
     $Headers.Add('Authorization',$AuthorizationHeader)
-    $Headers.Add('Accept','application/json')
+    $Headers.Add('Accept',$AcceptHeader)
     $Headers.Add('Content-Type', 'application/json')
 
     #Add additional headers

--- a/shared/Invoke-AkamaiRestMethod.ps1
+++ b/shared/Invoke-AkamaiRestMethod.ps1
@@ -201,7 +201,7 @@ function Invoke-AkamaiRestMethod
                 else {
                     $Response = Invoke-RestMethod -Method $Method -Uri $ReqURL -Headers $Headers -Body $Body
                 }
-
+                
             }
             else {
                 if($UseProxy) {
@@ -226,7 +226,7 @@ function Invoke-AkamaiRestMethod
                 else {
                     $Response = Invoke-RestMethod -Method $Method -Uri $ReqURL -Headers $Headers -MaximumRedirection 0 -ErrorAction SilentlyContinue
                 }
-
+    
                 #Redirects aren't well handled due to signatures needing regenerated
                 if($Response.redirectLink){
                     $Response = Invoke-AkamaiRestMethod -Method $Method -Path $Response.redirectLink  -AdditionalHeaders $AdditionalHeaders -EdgeRCFile $EdgeRCFile -Section $Section


### PR DESCRIPTION
This change addresses issue #2 ~by adding an optional `-AcceptHeader` parameter to `Invoke-AkamaiRestMethod` which defaults to `application/json`~. `Get-MasterZoneFile` was modified to use the `AdditionalHeaders` parameter to set the accept header for its request to `text/dns`.
