### PR TITLE
Fix for Get-MasterZoneFile HTTP 406 error

### DIFF
--- a/fastdns/Get-MasterZoneFile.ps1
+++ b/fastdns/Get-MasterZoneFile.ps1
@@ -8,9 +8,12 @@ function Get-MasterZoneFile
     )
 
     $Path = "/config-dns/v2/zones/$Zone/zone-file`?accountSwitchKey=$AccountSwitchKey"
+    $AdditionalHeaders = @{
+        Accept = 'text/dns'
+    }
 
     try {
-        $Result = Invoke-AkamaiRestMethod -Method GET -Path $Path -EdgeRCFile $EdgeRCFile -Section $Section
+        $Result = Invoke-AkamaiRestMethod -Method GET -Path $Path -AdditionalHeaders $AdditionalHeaders -EdgeRCFile $EdgeRCFile -Section $Section
         return $Result
     }
     catch {


### PR DESCRIPTION
This change addresses issue #2 by adding the proper `text/dns` Accept header to `Get-MasterZoneFile`.