### PR TITLE
Fix invalid signature errors when sending POST with no Body

### DIFF
--- a/shared/Invoke-AkamaiRestMethod.ps1
+++ b/shared/Invoke-AkamaiRestMethod.ps1
@@ -176,6 +176,10 @@ function Invoke-AkamaiRestMethod
             $SignatureData += "`t`t" + $Body_Hash + "`t"
             Write-Debug "Signature generated from input file $InputFile"
         }
+        else
+        {
+            $SignatureData += "`t`t`t"
+        }
     }
     else
     {


### PR DESCRIPTION
The change addresses issue #13 by completing the signature data even when using a POST with no Body or InputFile arguments.